### PR TITLE
mod items_controller

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,4 +1,5 @@
-class ItemsController < ActionController::Base
+# class ItemsController < ActionController::Base
+class ItemsController < ApplicationController
 	before_action :move_to_index, except: :index
 
 	def index

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,4 +1,3 @@
-# class ItemsController < ActionController::Base
 class ItemsController < ApplicationController
 	before_action :move_to_index, except: :index
 


### PR DESCRIPTION
初期表示画面におけるバグを修正しました。
原因は、items_controller.rb に継承するクラスの記述を誤っていたようです。
（手動で作成した際、application_controller.rb の記述をコピペしたと思われる。。）